### PR TITLE
Add support for encrypted async blob read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add metrics for thread_pool task wait time ([#9681](https://github.com/opensearch-project/OpenSearch/pull/9681))
 - Async blob read support for S3 plugin ([#9694](https://github.com/opensearch-project/OpenSearch/pull/9694))
 - [Telemetry-Otel] Added support for OtlpGrpcSpanExporter exporter ([#9666](https://github.com/opensearch-project/OpenSearch/pull/9666))
+- Async blob read support for encrypted containers ([#10131](https://github.com/opensearch-project/OpenSearch/pull/10131))
 
 ### Dependencies
 - Bump `peter-evans/create-or-update-comment` from 2 to 3 ([#9575](https://github.com/opensearch-project/OpenSearch/pull/9575))

--- a/server/src/main/java/org/opensearch/common/blobstore/EncryptedBlobContainer.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/EncryptedBlobContainer.java
@@ -50,7 +50,7 @@ public class EncryptedBlobContainer<T, U> implements BlobContainer {
         return cryptoHandler.createDecryptingStream(inputStream);
     }
 
-    private EncryptedHeaderContentSupplier getEncryptedHeaderContentSupplier(String blobName) {
+    EncryptedHeaderContentSupplier getEncryptedHeaderContentSupplier(String blobName) {
         return (start, end) -> {
             byte[] buffer;
             int length = (int) (end - start + 1);

--- a/server/src/main/java/org/opensearch/common/blobstore/stream/read/ReadContext.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/stream/read/ReadContext.java
@@ -28,6 +28,12 @@ public class ReadContext {
         this.blobChecksum = blobChecksum;
     }
 
+    public ReadContext(ReadContext readContext) {
+        this.blobSize = readContext.blobSize;
+        this.partStreams = readContext.partStreams;
+        this.blobChecksum = readContext.blobChecksum;
+    }
+
     public String getBlobChecksum() {
         return blobChecksum;
     }

--- a/server/src/test/java/org/opensearch/common/blobstore/AsyncMultiStreamEncryptedBlobContainerTests.java
+++ b/server/src/test/java/org/opensearch/common/blobstore/AsyncMultiStreamEncryptedBlobContainerTests.java
@@ -1,0 +1,121 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.blobstore;
+
+import org.opensearch.common.Randomness;
+import org.opensearch.common.blobstore.stream.read.ReadContext;
+import org.opensearch.common.blobstore.stream.read.listener.ListenerTestUtils;
+import org.opensearch.common.crypto.CryptoHandler;
+import org.opensearch.common.crypto.DecryptedRangedStreamProvider;
+import org.opensearch.common.io.InputStreamContainer;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.function.UnaryOperator;
+
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AsyncMultiStreamEncryptedBlobContainerTests extends OpenSearchTestCase {
+
+    // Tests the happy path scenario for decrypting a read context
+    @SuppressWarnings("unchecked")
+    public void testReadBlobAsync() throws Exception {
+        String testBlobName = "testBlobName";
+        int size = 100;
+
+        // Mock objects needed for the test
+        AsyncMultiStreamBlobContainer blobContainer = mock(AsyncMultiStreamBlobContainer.class);
+        CryptoHandler<Object, Object> cryptoHandler = mock(CryptoHandler.class);
+        Object cryptoContext = mock(Object.class);
+        when(cryptoHandler.loadEncryptionMetadata(any())).thenReturn(cryptoContext);
+        when(cryptoHandler.estimateDecryptedLength(any(), anyLong())).thenReturn((long) size);
+        long[] adjustedRanges = { 0, size - 1 };
+        DecryptedRangedStreamProvider rangedStreamProvider = new DecryptedRangedStreamProvider(adjustedRanges, UnaryOperator.identity());
+        when(cryptoHandler.createDecryptingStreamOfRange(eq(cryptoContext), anyLong(), anyLong())).thenReturn(rangedStreamProvider);
+
+        // Objects needed for API call
+        final byte[] data = new byte[size];
+        Randomness.get().nextBytes(data);
+        final InputStreamContainer inputStreamContainer = new InputStreamContainer(new ByteArrayInputStream(data), data.length, 0);
+        final ListenerTestUtils.CountingCompletionListener<ReadContext> completionListener =
+            new ListenerTestUtils.CountingCompletionListener<>();
+        final ReadContext readContext = new ReadContext(size, List.of(inputStreamContainer), null);
+
+        Mockito.doAnswer(invocation -> {
+            ActionListener<ReadContext> readContextActionListener = invocation.getArgument(1);
+            readContextActionListener.onResponse(readContext);
+            return null;
+        }).when(blobContainer).readBlobAsync(eq(testBlobName), any());
+
+        AsyncMultiStreamEncryptedBlobContainer<Object, Object> asyncMultiStreamEncryptedBlobContainer =
+            new AsyncMultiStreamEncryptedBlobContainer<>(blobContainer, cryptoHandler);
+        asyncMultiStreamEncryptedBlobContainer.readBlobAsync(testBlobName, completionListener);
+
+        // Assert results
+        ReadContext response = completionListener.getResponse();
+        assertEquals(0, completionListener.getFailureCount());
+        assertEquals(1, completionListener.getResponseCount());
+        assertNull(completionListener.getException());
+
+        assertTrue(response instanceof AsyncMultiStreamEncryptedBlobContainer.DecryptedReadContext);
+        assertEquals(1, response.getNumberOfParts());
+        assertEquals(size, response.getBlobSize());
+
+        InputStreamContainer responseContainer = response.getPartStreams().get(0);
+        assertEquals(0, responseContainer.getOffset());
+        assertEquals(size, responseContainer.getContentLength());
+        assertEquals(100, responseContainer.getInputStream().available());
+    }
+
+    // Tests the exception scenario for decrypting a read context
+    @SuppressWarnings("unchecked")
+    public void testReadBlobAsyncException() throws Exception {
+        String testBlobName = "testBlobName";
+        int size = 100;
+
+        // Mock objects needed for the test
+        AsyncMultiStreamBlobContainer blobContainer = mock(AsyncMultiStreamBlobContainer.class);
+        CryptoHandler<Object, Object> cryptoHandler = mock(CryptoHandler.class);
+        when(cryptoHandler.loadEncryptionMetadata(any())).thenThrow(new IOException());
+
+        // Objects needed for API call
+        final byte[] data = new byte[size];
+        Randomness.get().nextBytes(data);
+        final InputStreamContainer inputStreamContainer = new InputStreamContainer(new ByteArrayInputStream(data), data.length, 0);
+        final ListenerTestUtils.CountingCompletionListener<ReadContext> completionListener =
+            new ListenerTestUtils.CountingCompletionListener<>();
+        final ReadContext readContext = new ReadContext(size, List.of(inputStreamContainer), null);
+
+        Mockito.doAnswer(invocation -> {
+            ActionListener<ReadContext> readContextActionListener = invocation.getArgument(1);
+            readContextActionListener.onResponse(readContext);
+            return null;
+        }).when(blobContainer).readBlobAsync(eq(testBlobName), any());
+
+        AsyncMultiStreamEncryptedBlobContainer<Object, Object> asyncMultiStreamEncryptedBlobContainer =
+            new AsyncMultiStreamEncryptedBlobContainer<>(blobContainer, cryptoHandler);
+        asyncMultiStreamEncryptedBlobContainer.readBlobAsync(testBlobName, completionListener);
+
+        // Assert results
+        assertEquals(1, completionListener.getFailureCount());
+        assertEquals(0, completionListener.getResponseCount());
+        assertNull(completionListener.getResponse());
+        assertTrue(completionListener.getException() instanceof IOException);
+    }
+
+}

--- a/server/src/test/java/org/opensearch/common/blobstore/stream/read/listener/ListenerTestUtils.java
+++ b/server/src/test/java/org/opensearch/common/blobstore/stream/read/listener/ListenerTestUtils.java
@@ -19,7 +19,7 @@ public class ListenerTestUtils {
      * CountingCompletionListener acts as a verification instance for wrapping listener based calls.
      * Keeps track of the last response, failure and count of response and failure invocations.
      */
-    static class CountingCompletionListener<T> implements ActionListener<T> {
+    public static class CountingCompletionListener<T> implements ActionListener<T> {
         private int responseCount;
         private int failureCount;
         private T response;


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
